### PR TITLE
fix: vec-264 use arguments as the single point of truth for avs client configs

### DIFF
--- a/basic-search/README.md
+++ b/basic-search/README.md
@@ -28,6 +28,12 @@ python3 -m pip install -r requirements.txt
 
 ## Run the search demo
 
+Run with --help to see available the example's available configuration.
+```shell
+python3 search.py --help
+```
+
+Run the example.
 ```shell
 python3 search.py
 ```

--- a/basic-search/search.py
+++ b/basic-search/search.py
@@ -1,42 +1,51 @@
+import argparse
+
 from aerospike_vector_search import types
 from aerospike_vector_search import AdminClient, Client
 
-host = "localhost"
-port = 5000
 listener_name = None
+index_name = "basic_index"
 
-namespace = "test"
-set_name = "simple_search"
-index_name = "simple_index"
+arg_parser = argparse.ArgumentParser(description="Aerospike Vector Search Example")
+arg_parser.add_argument("--host", dest="host", required=False, default="localhost", help="Aerospike Vector Search host.")
+arg_parser.add_argument("--port", dest="port", required=False, default=5000, help="Aerospike Vector Search port.")
+arg_parser.add_argument("--namespace", dest="namespace", required=False, default="test", help="Aerospike namespace for vector index and data.")
+arg_parser.add_argument("--set", dest="set", required=False, default="basic_search", help="Aerospike set for vector index and data.")
+arg_parser.add_argument("--load-balancer", dest="load_balancer", action="store_true", required=False, default=False, help="Use this if the host is a load balancer.")
+args = arg_parser.parse_args()
 
 with AdminClient(
-    seeds=types.HostPort(host=host, port=port), listener_name=listener_name
+    seeds=types.HostPort(host=args.host, port=args.port),
+    listener_name=listener_name,
+    is_loadbalancer=args.load_balancer,
 ) as adminClient:
     try:
         print("creating index")
         adminClient.index_create(
-            namespace=namespace,
+            namespace=args.namespace,
             name=index_name,
             vector_field="vector",
             dimensions=2,
-            sets=set_name,
+            sets=args.set,
         )
     except Exception as e:
         print("failed creating index " + str(e))
         pass
 
 with Client(
-    seeds=types.HostPort(host=host, port=port), listener_name=listener_name
+    seeds=types.HostPort(host=args.host, port=args.port),
+    listener_name=listener_name,
+    is_loadbalancer=args.load_balancer,
 ) as client:
     print("inserting vectors")
     for i in range(10):
         key = "r" + str(i)
         if not client.is_indexed(
-            namespace="test", set_name=set_name, key=key, index_name=index_name
+            namespace=args.namespace, set_name=args.set, key=key, index_name=index_name
         ):
             client.upsert(
-                namespace=namespace,
-                set_name=set_name,
+                namespace=args.namespace,
+                set_name=args.set,
                 key=key,
                 record_data={
                     "url": f"http://host.com/data{i}",
@@ -47,13 +56,13 @@ with Client(
             )
 
     print("waiting for indexing to complete")
-    client.wait_for_index_completion(namespace="test", name=index_name)
+    client.wait_for_index_completion(namespace=args.namespace, name=index_name)
 
     print("querying")
     for i in range(10):
         print("   query " + str(i))
         results = client.vector_search(
-            namespace=namespace,
+            namespace=args.namespace,
             index_name=index_name,
             query=[i * 1.0, i * 1.0],
             limit=10,

--- a/basic-search/search.py
+++ b/basic-search/search.py
@@ -7,11 +7,42 @@ listener_name = None
 index_name = "basic_index"
 
 arg_parser = argparse.ArgumentParser(description="Aerospike Vector Search Example")
-arg_parser.add_argument("--host", dest="host", required=False, default="localhost", help="Aerospike Vector Search host.")
-arg_parser.add_argument("--port", dest="port", required=False, default=5000, help="Aerospike Vector Search port.")
-arg_parser.add_argument("--namespace", dest="namespace", required=False, default="test", help="Aerospike namespace for vector index and data.")
-arg_parser.add_argument("--set", dest="set", required=False, default="basic_search", help="Aerospike set for vector index and data.")
-arg_parser.add_argument("--load-balancer", dest="load_balancer", action="store_true", required=False, default=False, help="Use this if the host is a load balancer.")
+arg_parser.add_argument(
+    "--host",
+    dest="host",
+    required=False,
+    default="localhost",
+    help="Aerospike Vector Search host.",
+)
+arg_parser.add_argument(
+    "--port",
+    dest="port",
+    required=False,
+    default=5000,
+    help="Aerospike Vector Search port.",
+)
+arg_parser.add_argument(
+    "--namespace",
+    dest="namespace",
+    required=False,
+    default="test",
+    help="Aerospike namespace for vector index and data.",
+)
+arg_parser.add_argument(
+    "--set",
+    dest="set",
+    required=False,
+    default="basic_search",
+    help="Aerospike set for vector index and data.",
+)
+arg_parser.add_argument(
+    "--load-balancer",
+    dest="load_balancer",
+    action="store_true",
+    required=False,
+    default=False,
+    help="Use this if the host is a load balancer.",
+)
 args = arg_parser.parse_args()
 
 with AdminClient(


### PR DESCRIPTION
This PR fixes the inconsistent use of hardcoded namespaces and other arguments in the simple search example. Instead, command line arguments are used. This also adds the --load-balancer flag to enable load balanced mode. I tested this locally with with and without load balancers.

```
python3 search.py --help
usage: search.py [-h] [--host HOST] [--port PORT] [--namespace NAMESPACE] [--set SET] [--load-balancer]

Aerospike Vector Search Example

options:
  -h, --help            show this help message and exit
  --host HOST           Aerospike Vector Search host.
  --port PORT           Aerospike Vector Search port.
  --namespace NAMESPACE
                        Aerospike namespace for vector index and data.
  --set SET             Aerospike set for vector index and data.
  --load-balancer       Use this if the host is a load balancer.
```