### PR TITLE
chore: vec-290 change basic, quote, and prism example default AVS dat…

### DIFF
--- a/.github/workflows/upload-images.yml
+++ b/.github/workflows/upload-images.yml
@@ -45,7 +45,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        file: .internal/Dockerfile-quote-search-preview
+        file: ./.internal/Dockerfile-quote-search-preview
         platforms: linux/amd64,linux/arm64
         push: true
         tags: aerospike/quote-search-example:preview
@@ -67,8 +67,8 @@ jobs:
     - name: Build and push quote search Docker image
       uses: docker/build-push-action@v6
       with:
-        context: quote-semantic-search
-        file: Dockerfile-quote-search
+        context: ./quote-semantic-search
+        file: ./quote-semantic-search/Dockerfile-quote-search
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |
@@ -92,8 +92,8 @@ jobs:
     - name: Build and push prism search Docker image
       uses: docker/build-push-action@v6
       with:
-        context: prism-image-search
-        file: Dockerfile-prism
+        context: ./prism-image-search
+        file: ./prism-image-search/Dockerfile-prism
         platforms: linux/amd64,linux/arm64
         push: true
         tags: |

--- a/basic-search/README.md
+++ b/basic-search/README.md
@@ -24,7 +24,26 @@ source .venv/bin/activate
 python3 -m pip install -r requirements.txt
 ```
 
-```
+## Configuration
+
+The application can be configured by setting the following command line flags.
+If not set defaults are used.
+
+[!NOTE]
+It is best practice to store AVS index and record data in separate namespaces.
+By default this application stores its AVS index in the "avs-index" namespace, and AVS records in "avs-data".
+If your Aerospike database configuration does not define these namespaces you will see an error.
+You may change the --namespace and --index-namespace to other values, like the default Aerospike "test" namespace, to use other namespaces.
+
+| Command Line Flag        | Default            | Description                                                        |
+|-----------------------------|--------------------|-----------------------------------------------------------------|
+| --host               | localhost          | AVS server seed host                                                   |
+| --port               | 5000               | AVS server seed host port                                              |
+| --namespace          | avs-data           | The Aerospike namespace for storing the quote records                  |
+| --set                | basic-data         | The Aerospike set for storing the quote records                        |
+| --index-namespace    | avs-index          | The Aerospike namespace for storing the HNSW index                     |
+| --index-set          | basic-index        | The Aerospike set for storing the HNSW index                           |
+| --load-balancer      | False              |                 If true, the first seed address will be treated as a load balancer node.```
 
 ## Run the search demo
 

--- a/basic-search/search.py
+++ b/basic-search/search.py
@@ -25,15 +25,29 @@ arg_parser.add_argument(
     "--namespace",
     dest="namespace",
     required=False,
-    default="test",
-    help="Aerospike namespace for vector index and data.",
+    default="avs-data",
+    help="Aerospike namespace for vector data.",
 )
 arg_parser.add_argument(
     "--set",
     dest="set",
     required=False,
-    default="basic_search",
-    help="Aerospike set for vector index and data.",
+    default="basic-data",
+    help="Aerospike set for vector data.",
+)
+arg_parser.add_argument(
+    "--index-namespace",
+    dest="index_namespace",
+    required=False,
+    default="avs-index",
+    help="Aerospike namespace the for vector index.",
+)
+arg_parser.add_argument(
+    "--index-set",
+    dest="index_set",
+    required=False,
+    default="basic-index",
+    help="Aerospike set for the vector index.",
 )
 arg_parser.add_argument(
     "--load-balancer",
@@ -58,6 +72,7 @@ with AdminClient(
             vector_field="vector",
             dimensions=2,
             sets=args.set,
+            index_storage=types.IndexStorage(namespace=args.index_namespace, set_name=args.index_set),
         )
     except Exception as e:
         print("failed creating index " + str(e))

--- a/prism-image-search/README.md
+++ b/prism-image-search/README.md
@@ -102,6 +102,12 @@ python3 -m pip install -r requirements.txt
 The application can be configured by setting the following environment variable.
 If not set defaults are used.
 
+[!NOTE]
+It is best practice to store AVS index and record data in separate namespaces.
+By default this application stores its AVS index in the "avs-index" namespace, and AVS records in "avs-data".
+If your Aerospike database configuration does not define these namespaces you will see an error.
+You may change the AVS_NAMESPACE and AVS_INDEX_NAMESPACE to other values, like the default Aerospike "test" namespace, to use other namespaces.
+
 | Environment Variable   | Default            | Description                                                     |
 |------------------------|--------------------|-----------------------------------------------------------------|
 | APP_USERNAME           |                    | If set, the username for basic authentication                   |
@@ -110,9 +116,9 @@ If not set defaults are used.
 | AVS_HOST               | localhost          | AVS server seed host                                            |
 | AVS_PORT               | 5000               | AVS server seed host port                                       |
 | AVS_ADVERTISED_LISTENER|                    | An optional advertised listener to use if configured on the AVS server                              |
-| AVS_NAMESPACE     | test               | The Aerospike namespace for storing the image records           |
+| AVS_NAMESPACE     | avs-data               | The Aerospike namespace for storing the image records           |
 | AVS_SET           | image-data         | The Aerospike set for storing the image records                 |
-| AVS_INDEX_NAMESPACE     | test               | The Aerospike namespace for storing the HNSW index              |
+| AVS_INDEX_NAMESPACE     | avs-index               | The Aerospike namespace for storing the HNSW index              |
 | AVS_INDEX_SET           | image-index        | The Aerospike set for storing the HNSW index                    |
 | AVS_INDEX_NAME         | prism-image-search | The name of the  index                                          |
 | AVS_MAX_RESULTS        | 20                 | Maximum number of vector search results to return               |

--- a/prism-image-search/docker-compose.yml
+++ b/prism-image-search/docker-compose.yml
@@ -46,11 +46,6 @@ services:
       AVS_PORT: "5000"
       APP_NUM_QUOTES: "5000"
       GRPC_DNS_RESOLVER: native
-      # comment out the following lines to use the default namespace (test) to store all index and vector data
-      AVS_NAMESPACE: avs-data
-      AVS_SET: quote-data
-      AVS_INDEX_NAMESPACE: avs-index
-      AVS_INDEX_SET: quote-index
     volumes:
       - ./container-volumes/prism/images:/prism/static/images/data
 

--- a/prism-image-search/prism/config.py
+++ b/prism-image-search/prism/config.py
@@ -23,9 +23,9 @@ class Config(object):
     AVS_PORT = int(os.environ.get("AVS_PORT") or 5000)
     AVS_ADVERTISED_LISTENER = os.environ.get("AVS_ADVERTISED_LISTENER") or None
     AVS_INDEX_NAME = os.environ.get("AVS_INDEX_NAME") or "prism-image-search"
-    AVS_NAMESPACE = os.environ.get("AVS_NAMESPACE") or "test"
+    AVS_NAMESPACE = os.environ.get("AVS_NAMESPACE") or "avs-data"
     AVS_SET = os.environ.get("AVS_SET") or "image-data"
-    AVS_INDEX_NAMESPACE = os.environ.get("AVS_INDEX_NAMESPACE") or "test"
+    AVS_INDEX_NAMESPACE = os.environ.get("AVS_INDEX_NAMESPACE") or "avs-index"
     AVS_INDEX_SET = os.environ.get("AVS_INDEX_SET") or "image-index"
     AVS_VERIFY_TLS = get_bool_env("VERIFY_TLS", True)
     AVS_MAX_RESULTS = int(os.environ.get("AVS_MAX_RESULTS") or 20)

--- a/quote-semantic-search/README.md
+++ b/quote-semantic-search/README.md
@@ -92,6 +92,12 @@ python3 -m pip install -r requirements.txt
 The application can be configured by setting the following environment variable.
 If not set defaults are used.
 
+[!NOTE]
+It is best practice to store AVS index and record data in separate namespaces.
+By default this application stores its AVS index in the "avs-index" namespace, and AVS records in "avs-data".
+If your Aerospike database configuration does not define these namespaces you will see an error.
+You may change the AVS_NAMESPACE and AVS_INDEX_NAMESPACE to other values, like the default Aerospike "test" namespace, to use other namespaces.
+
 | Environment Variable        | Default            | Description                                                     |
 |-----------------------------|--------------------|-----------------------------------------------------------------|
 | APP_USERNAME          |                    | If set, the username for basic authentication                   |
@@ -101,9 +107,9 @@ If not set defaults are used.
 | AVS_HOST               | localhost          | AVS server seed host                                       |
 | AVS_PORT               | 5000               | AVS server seed host port                                  |
 | AVS_ADVERTISED_LISTENER|                    | An optional advertised listener to use if configured on the AVS server                              |
-| AVS_NAMESPACE     | test               | The Aerospike namespace for storing the quote records           |
+| AVS_NAMESPACE     | avs-data               | The Aerospike namespace for storing the quote records           |
 | AVS_SET           | quote-data         | The Aerospike set for storing the quote records                 |
-| AVS_INDEX_NAMESPACE     | test               | The Aerospike namespace for storing the HNSW index              |
+| AVS_INDEX_NAMESPACE     | avs-index               | The Aerospike namespace for storing the HNSW index              |
 | AVS_INDEX_SET           | quote-index        | The Aerospike set for storing the HNSW index                    |
 | AVS_INDEX_NAME         | quote-search       | The name of the  index                                          |
 | AVS_MAX_RESULTS        | 20                 | Maximum number of vector search results to return               |

--- a/quote-semantic-search/docker-compose.yml
+++ b/quote-semantic-search/docker-compose.yml
@@ -50,11 +50,6 @@ services:
       AVS_PORT: "5000"
       APP_NUM_QUOTES: "5000"
       GRPC_DNS_RESOLVER: native
-      # comment out the following lines to use the default namespace (test) to store all index and vector data
-      AVS_NAMESPACE: avs-data
-      AVS_SET: quote-data
-      AVS_INDEX_NAMESPACE: avs-index
-      AVS_INDEX_SET: quote-index
 
 networks:
   avs-demo: {}

--- a/quote-semantic-search/quote-search/config.py
+++ b/quote-semantic-search/quote-search/config.py
@@ -21,9 +21,9 @@ class Config(object):
     AVS_PORT = int(os.environ.get("AVS_PORT") or 5000)
     AVS_ADVERTISED_LISTENER = os.environ.get("AVS_ADVERTISED_LISTENER") or None
     AVS_INDEX_NAME = os.environ.get("AVS_INDEX_NAME") or "quote-semantic-search"
-    AVS_NAMESPACE = os.environ.get("AVS_NAMESPACE") or "test"
+    AVS_NAMESPACE = os.environ.get("AVS_NAMESPACE") or "avs-data"
     AVS_SET = os.environ.get("AVS_SET") or "quote-data"
-    AVS_INDEX_NAMESPACE = os.environ.get("AVS_INDEX_NAMESPACE") or "test"
+    AVS_INDEX_NAMESPACE = os.environ.get("AVS_INDEX_NAMESPACE") or "avs-index"
     AVS_INDEX_SET = os.environ.get("AVS_INDEX_SET") or "quote-index"
     AVS_VERIFY_TLS = get_bool_env("VERIFY_TLS", True)
     AVS_MAX_RESULTS = int(os.environ.get("AVS_MAX_RESULTS") or 5)


### PR DESCRIPTION
…a and index namespaces to avs-data and avs-index. Also adds a readme note about the use of separate namespaces for AVS to each example.